### PR TITLE
Added pod abstract and Changes file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module RT::Extension::ResetPassword
 
 0.06
+    - Added pod abstract (which MetaCPAN, search.cpan.org, etc expect to find)
     - Added Changes file, populated from git log comments
 
 0.05 2012-02-07

--- a/lib/RT/Extension/ResetPassword.pm
+++ b/lib/RT/Extension/ResetPassword.pm
@@ -2,6 +2,10 @@ package RT::Extension::ResetPassword;
 
 our $VERSION = '0.05';
 
+=head1 NAME
+
+RT::Extension::ResetPassword - add "forgot your password?" link to RT instance
+
 =head1 DESCRIPTION
 
 This extension for RT adds a new "Forgot your password?" link to the front


### PR DESCRIPTION
Hi,

I added a pod abstract, following the convention for format. Various tools expect to find an abstract. For example, MetaCPAN presents your module differently to most modules, because it can't find an abstract.

I also added a Changes file, which follows the conventions in CPAN::Changes::Spec.

Cheers,
Neil
