### PR TITLE
optionally hide failures to request password resets

### DIFF
--- a/html/NoAuth/ResetPassword/Request.html
+++ b/html/NoAuth/ResetPassword/Request.html
@@ -91,10 +91,17 @@ if ($ARGS{'Email'}) {
         }
     } elsif ($u->id and $u->Disabled) {
         push @actions, loc("You can't reset your password because your user is disabled.");
+        RT->Logger->warning("Disabled user " . $u->Name . " attempted to reset password");
     } elsif ($u->id) {
         push @actions, loc("You can't reset your password as you don't already have one.");
+        RT->Logger->warning("User " . $u->Name . " with no password attempted a password reset")
     } else {
         push @actions, loc("RT couldn't find a user with that email address. Give it another try?");
+        RT->Logger->warning("Password reset attempted for non-existent user " . $u->EmailAddress);
+    }
+    if(RT->Config->Get("HidePasswordResetErrors") == 1) {
+        pop @actions;
+        push @actions, loc("RT has sent you an email message with instructions about how to reset your password");
     }
 }
 </%INIT>

--- a/lib/RT/Extension/ResetPassword.pm
+++ b/lib/RT/Extension/ResetPassword.pm
@@ -73,6 +73,13 @@ The contents of the email sent to users can be found in the global
 PasswordReset template (do not confuse this with the core PasswordChange
 template).
 
+If you want to prevent unauthorised visitors from determining what user
+accounts exist and whether they are disabled, set HidePasswordResetErrors
+to 1 in your RT configuration; then any password reset request will
+appear to the requestor to have resulted in an email being sent, thus
+not revealing the reasons for any failure. All failures will still be
+logged with an appropriate diagnostic message.
+
 =head1 AUTHOR
 
 Jesse Vincent <jesse at bestpractical.com>


### PR DESCRIPTION
Set HidePasswordResetErrors in RT config to make all password reset
requests look to the requestor as though they have successfully sent an
email. Thus an unauthorised visitor can't find out whether a given user
account exists or is disabled.
