### PR TITLE
Update to Password Reset Template

### DIFF
--- a/etc/initialdata
+++ b/etc/initialdata
@@ -6,7 +6,7 @@
 
 Greetings,
 
-Someone at { RT::Interface::Web::RequestENV(\'REMOTE_ADDR\') } requested that RT send you this message
+Someone at { RT::Interface::Web::RequestENV(\'HTTP_X_FORWARDED_FOR\') || RT::Interface::Web::RequestENV(\'REMOTE_ADDR\') } requested that RT send you this message
 allowing you to reset your password. If you didn\'t request this message, please
 notify your RT administrator immediately.
 


### PR DESCRIPTION
Use ip address in HTTP_X_FORWARDED_FOR environment variable if it exists
if not then fallback to using REMOTE_ADDR.

I've added this because if RT is behind a reverse proxy then the proxy ip address gets added to the email rather than the clients ip address.

All the best
Martin