### PR TITLE
Add name to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use inc::Module::Install;
 RTx('RT-Extension-ResetPassword');
+name 'RT-Extension-ResetPassword';
 
 sign;
 &WriteAll;


### PR DESCRIPTION
The name parameter was missing from the makefile, which causes dh-make-perl to fail when trying to package this library for ubuntu